### PR TITLE
Refactor entry generation to remove flatmap

### DIFF
--- a/build/webpack.config.dev.js
+++ b/build/webpack.config.dev.js
@@ -12,17 +12,13 @@ const config = require('./config')
 
 const baseEntries = Object.keys(config.common.entry)
 // Add Webpack HMR-polling to every entry
-const entries = baseEntries.flatMap(entry => ({
-      [entry]: [
-        'webpack/hot/poll?1000',
-        config.common.entry[entry]
-      ]
-    })
-  )
-  .reduce((entry, entryObj) => ({
-    ...entryObj,
-    ...entry
-  }), {})
+const entries = Object.entries(config.common.entry).reduce(
+    (out, [entryKey, entryValue]) => ({
+        ...out,
+        [entryKey]: ["webpack/hot/poll?1000", entryValue]
+    }),
+    {}
+);
 
 module.exports = merge(baseConfig, {
   entry: entries,


### PR DESCRIPTION
This maintains the current behaviour, but removes the dependency on node >=11 by not using flatmap.